### PR TITLE
removing earthlab.github.io url from basepath

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ title                    : "Earth Lab Resources"
 title_separator          : "-"
 name                     : "Earth Analytics"
 description              : "Code, tutorials, and tools for modern Earth analytics"
-url                      : "https://earthlab.github.io"
+url                      : ""
 baseurl                  : "/dev-earthlab-site"
 gh_repo                  :
 teaser                   : # filename of teaser fallback teaser image placed in /images/, .e.g. "500x300.png"


### PR DESCRIPTION
When the url is specified as "https://earthlab.github.io", that gets appended to images and links even when hosting locally. I removed this so that we can still navigate around easily when using `jekyll serve`.
